### PR TITLE
Add iteration control for TCM models

### DIFF
--- a/petprep_km/cli/run.py
+++ b/petprep_km/cli/run.py
@@ -88,6 +88,7 @@ def main():
             model_kwargs["blood_values"] = blood_values
             model_kwargs["vB_fixed"] = args.vb_fixed
             model_kwargs["fit_end_time"] = args.fit_end_time
+            model_kwargs["n_iterations"] = args.n_iterations
 
         if args.model in ["logan", "ma1"]:
             model_kwargs["t_star"] = args.tstar


### PR DESCRIPTION
## Summary
- pipe `--n-iterations` from CLI to 1TCM/2TCM constructors
- allow OneTCMModel and TwoTCMModel to specify `n_iterations`

## Testing
- `python -m py_compile petprep_km/interfaces/models.py petprep_km/cli/run.py`
- `python -m pip install -e .` *(fails: could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68852561e9508330a733383704cddbc6