### PR TITLE
Use fully qualified imports in example scripts

### DIFF
--- a/run_1tcm_example.py
+++ b/run_1tcm_example.py
@@ -1,6 +1,6 @@
-from interfaces.models import OneTCMModel
-from interfaces.io import load_tacs, load_blood
-from utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
+from petprep_km.interfaces.models import OneTCMModel
+from petprep_km.interfaces.io import load_tacs, load_blood
+from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
 import os
 
 # Load data

--- a/run_2tcm_example.py
+++ b/run_2tcm_example.py
@@ -1,6 +1,6 @@
-from interfaces.models import TwoTCMModel
-from interfaces.io import load_tacs, load_blood
-from utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
+from petprep_km.interfaces.models import TwoTCMModel
+from petprep_km.interfaces.io import load_tacs, load_blood
+from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
 import os
 
 # Load data

--- a/run_logan_example.py
+++ b/run_logan_example.py
@@ -1,6 +1,6 @@
-from interfaces.models import LoganModel
-from interfaces.io import load_tacs, load_blood, load_morphology
-from utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
+from petprep_km.interfaces.models import LoganModel
+from petprep_km.interfaces.io import load_tacs, load_blood, load_morphology
+from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_html_report
 import os
 
 # Load data

--- a/run_ma1_example.py
+++ b/run_ma1_example.py
@@ -1,6 +1,6 @@
-from interfaces.models import MA1Model
-from interfaces.io import load_tacs, load_blood, load_morphology
-from utils.misc import save_kinpar_tsv, save_kinpar_json, plot_fit, generate_html_report
+from petprep_km.interfaces.models import MA1Model
+from petprep_km.interfaces.io import load_tacs, load_blood, load_morphology
+from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, plot_fit, generate_html_report
 import os
 import numpy as np
 from scipy.integrate import cumtrapz


### PR DESCRIPTION
## Summary
- update imports in example scripts to use the `petprep_km` package namespace
- ensure newlines at end of files

## Testing
- `python -m py_compile run_*_example.py`

------
https://chatgpt.com/codex/tasks/task_e_6885257459448330af9699551e123fee