### PR TITLE
Update example scripts

### DIFF
--- a/run_1tcm_example.py
+++ b/run_1tcm_example.py
@@ -4,8 +4,12 @@ from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_ht
 import os
 
 # Load data
-tac_times, roi_names, tac_values = load_tacs('data/sub-01_ses-baseline_desc-WhiteMatter_tacs.tsv')
-plasma_times, plasma_values, blood_values = load_blood('data/sub-01_ses-baseline_inputfunction.tsv')
+tac_times, roi_names, tac_values = load_tacs(
+    'data/derivatives/petprep/sub-01/pet/sub-01_desc-preproc_seg-gtm_timeseries.tsv'
+)
+plasma_times, plasma_values, blood_values = load_blood(
+    'data/derivatives/bloodstream/sub-01/pet/sub-01_inputfunction.tsv'
+)
 
 # Parameters
 subject_id = "01"

--- a/run_2tcm_example.py
+++ b/run_2tcm_example.py
@@ -4,8 +4,12 @@ from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_ht
 import os
 
 # Load data
-tac_times, roi_names, tac_values = load_tacs('data/sub-01_ses-baseline_desc-WhiteMatter_tacs.tsv')
-plasma_times, plasma_values, blood_values = load_blood('data/sub-01_ses-baseline_inputfunction.tsv')
+tac_times, roi_names, tac_values = load_tacs(
+    'data/derivatives/petprep/sub-01/pet/sub-01_desc-preproc_seg-gtm_timeseries.tsv'
+)
+plasma_times, plasma_values, blood_values = load_blood(
+    'data/derivatives/bloodstream/sub-01/pet/sub-01_inputfunction.tsv'
+)
 
 # Parameters
 subject_id = "pf11"

--- a/run_logan_example.py
+++ b/run_logan_example.py
@@ -4,8 +4,12 @@ from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, generate_ht
 import os
 
 # Load data
-tac_times, roi_names, tac_values = load_tacs('data/sub-pf11_ses-pf974_desc-gtmseg_tacs.tsv')
-plasma_times, plasma_values, blood_values = load_blood('data/sub-pf11_ses-pf974_inputfunction.tsv')
+tac_times, roi_names, tac_values = load_tacs(
+    'data/derivatives/petprep/sub-01/pet/sub-01_desc-preproc_seg-gtm_timeseries.tsv'
+)
+plasma_times, plasma_values, blood_values = load_blood(
+    'data/derivatives/bloodstream/sub-01/pet/sub-01_inputfunction.tsv'
+)
 morphology = load_morphology('data/sub-pf11_ses-pf974_desc-gtmseg_morph.tsv')
 
 # Parameters

--- a/run_ma1_example.py
+++ b/run_ma1_example.py
@@ -1,14 +1,17 @@
 from petprep_km.interfaces.models import MA1Model
-from petprep_km.interfaces.io import load_tacs, load_blood, load_morphology
+from petprep_km.interfaces.io import load_tacs, load_blood
 from petprep_km.utils.misc import save_kinpar_tsv, save_kinpar_json, plot_fit, generate_html_report
 import os
 import numpy as np
 from scipy.integrate import cumtrapz
 
 # Load data
-tac_times, roi_names, tac_values = load_tacs('data/sub-pf11_ses-pf974_desc-gtmseg_tacs.tsv')
-plasma_times, plasma_values, blood_values = load_blood('data/sub-pf11_ses-pf974_inputfunction.tsv')
-morphology = load_morphology('data/sub-pf11_ses-pf974_desc-gtmseg_morph.tsv')
+tac_times, roi_names, tac_values = load_tacs(
+    'data/derivatives/petprep/sub-01/pet/sub-01_desc-preproc_seg-gtm_timeseries.tsv'
+)
+plasma_times, plasma_values, blood_values = load_blood(
+    'data/derivatives/bloodstream/sub-01/pet/sub-01_inputfunction.tsv'
+)
 
 # Parameters
 t_star = 41


### PR DESCRIPTION
## Summary
- use derivative PETprep and bloodstream files in example scripts
- remove unused `morphology` variable from MA1 example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885332c0ff0833089866b1717feba5f